### PR TITLE
Feature/styling

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -34,6 +34,7 @@ under the License.
     <style>
       <%= Rouge::Themes::MonokaiSublime.render(:scope => '.highlight') %>
     </style>
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
     <%= stylesheet_link_tag :screen, media: :screen %>
     <%= stylesheet_link_tag :print, media: :print %>
     <%= stylesheet_link_tag :groove, media: :screen %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -36,6 +36,7 @@ under the License.
     </style>
     <%= stylesheet_link_tag :screen, media: :screen %>
     <%= stylesheet_link_tag :print, media: :print %>
+    <%= stylesheet_link_tag :groove, media: :screen %>
     <% if current_page.data.search %>
       <%= javascript_include_tag  "all" %>
     <% else %>
@@ -51,7 +52,9 @@ under the License.
       </span>
     </a>
     <div class="toc-wrapper">
-      <%= image_tag "logo.png", class: 'logo' %>
+      <div class="logo-wrapper">
+        <%= image_tag "logo.png", class: 'logo' %>
+      </div>
       <% if language_tabs.any? %>
         <div class="lang-selector">
           <% language_tabs.each do |lang| %>

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -70,7 +70,7 @@ $phone-width: $tablet-width - $nav-width !default; // min width before reverting
 // FONTS
 ////////////////////
 %default-font {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-family: 'Roboto', sans-serif;
   font-size: 14px;
 }
 

--- a/source/stylesheets/groove.css.scss
+++ b/source/stylesheets/groove.css.scss
@@ -1,5 +1,9 @@
 $groove-color: #03A3BB;
 
+html {
+  font-family: 'Roboto', sans-serif;
+}
+
 a {
   color: $groove-color;
 }

--- a/source/stylesheets/groove.css.scss
+++ b/source/stylesheets/groove.css.scss
@@ -1,0 +1,19 @@
+$groove-color: #03A3BB;
+
+a {
+  color: $groove-color;
+}
+
+.logo-wrapper {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+.logo {
+  width: 131px;
+  height: 43px;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1395086/55997941-344c8280-5c71-11e9-87af-a5246975ae91.png)

- use white groove logo and center it
- roboto font
- anchor tags are now groove teal color.

Notice I've created a new sass file; we can henceforth put all our additional styles and overrides there.