### PR TITLE
Fixed typos

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -50,18 +50,12 @@ This redirection will also contain the previously passed `state` value, as a que
 
 ### Step 3: Exchange the authorization code for an access token
 
-Make a `POST` request to `https://auth.grooveapp.com/oauth/authorize/token`
+Make a `POST` request to `https://auth.grooveapp.com/oauth/token`
 
 ```shell
-curl -X POST "https://auth.grooveapp.com/oauth/authorize"
-  -H 'Content-Type: application/json'
-  -d '{
-    "grant_type": "authorization_code",
-    "code": "SomeAuthorizationCode",
-    "redirect_url": "SomeRedirectUri",
-    "client_id": "SomeClientId",
-    "client_secret": "SomeClientSecret"
-  }'
+curl -X POST "https://auth.grooveapp.com/oauth/token"
+  -H "Content-Type: application/x-www-form-urlencoded"
+  -d "grant_type=authorization_code&code=SomeAuthorizationCode&redirect_uri=SomeRedirectUri&client_id=SomeClientId&client_secret=SomeClientSecret"
 ```
 
 > The returned `JSON` will look something like


### PR DESCRIPTION
### Summary

![image](https://user-images.githubusercontent.com/8136030/60198074-a276ff00-97f5-11e9-9cfb-b6b2c3e95a04.png)

After helping @mzanini set up a local public API application, we ran into a couple mistakes in our documentation

1. Fix the documented token exchange endpoint
1. Fix the content type for the example token exchange request from `application/json` to `application/x-www-form-urlencoded`
1. Change request data to match updated content type header
